### PR TITLE
feat(headers): sets headers on response object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,18 +25,43 @@ exports.register = (server, options, next) => {
     options.redisClient.multi();
     options.redisClient.set(key, 0, 'EX', rate.window, 'NX'); // if key not found, insert key:0 with window seconds expiry
     options.redisClient.incr(key);
+    options.redisClient.ttl(key);
+
     return options.redisClient.exec()
     .then((results) => {
-      rate.current = results[1]; // result of 2nd redis instruction
+      const remaining = rate.limit - results[1];
+
+      rate.remaining = Math.max(remaining, 0);
+      rate.reset = Math.floor(new Date().getTime() / 1000) + results[2];
       request.plugins['hapi-rate-limit'].rate = rate;
 
-      if (rate.current > rate.limit) {
-        return reply(new (options.overLimitError(rate)));
+      if (remaining < 0) {
+        return reply(new options.overLimitError(rate));
       }
 
       return reply.continue();
     });
 
+  });
+
+  server.ext('onPreResponse', (request, reply) => {
+    const rate = request.plugins['hapi-rate-limit'].rate;
+
+    if (rate) {
+      // if an error was thrown, set headers on error-response instead
+      const headers = request.response.output ? request.response.output.headers : request.response.headers;
+
+      headers['X-Rate-Limit-Remaining'] = rate.remaining;
+      headers['X-Rate-Limit-Limit'] = rate.limit;
+      headers['X-Rate-Limit-Reset'] = rate.reset;
+
+      // legacy headers
+      headers['rate-limit-remaining'] = rate.remaining;
+      headers['rate-limit-limit'] = rate.limit;
+      headers['rate-limit-window'] = rate.window;
+    }
+
+    return reply.continue();
   });
 
   next();


### PR DESCRIPTION
### What:
- replaces `current` (number of requests made within current window) with `remaining` (remaining number of requests within current window)
- Sets response headers with 

```
  'x-rate-limit-limit': total number of requests allowed within the window,
  'x-rate-limit-remaining': remaining number of requests allows within current window
  'x-rate-limit-reset': time when rate-limiter will reset (in seconds-since-epoch)
```
