### PR TITLE
feat(api_key): abstracted getter for api_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ server.register([
 ```
 
 #### Options
-All options `(defaultRate, redisClient, overLimitError)` are required for the plugin to work properly.
+All options `(defaultRate, requestAPIKey, redisClient, overLimitError)` are required for the plugin to work properly.
 ##### `defaultRate`
 ```
 {
@@ -32,6 +32,9 @@ All options `(defaultRate, redisClient, overLimitError)` are required for the pl
   window: # of seconds before count resets
 }
 ```
+
+##### `requestAPIKey`
+A function that returns an api_key given a `request` object
 
 ##### `redisClient`
 A `then-redis` client that is already connected

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ exports.register = (server, options, next) => {
       rate.window = routeSettings.window;
     }
 
-    const key = `hapi-rate-limit:${request.route.method}:${request.route.path}:${request.auth.credentials.api_key}`;
+    const key = `hapi-rate-limit:${request.route.method}:${request.route.path}:${options.requestAPIKey(request)}`;
     options.redisClient.multi();
     options.redisClient.set(key, 0, 'EX', rate.window, 'NX'); // if key not found, insert key:0 with window seconds expiry
     options.redisClient.incr(key);
@@ -54,11 +54,6 @@ exports.register = (server, options, next) => {
       headers['X-Rate-Limit-Remaining'] = rate.remaining;
       headers['X-Rate-Limit-Limit'] = rate.limit;
       headers['X-Rate-Limit-Reset'] = rate.reset;
-
-      // legacy headers
-      headers['rate-limit-remaining'] = rate.remaining;
-      headers['rate-limit-limit'] = rate.limit;
-      headers['rate-limit-window'] = rate.window;
     }
 
     return reply.continue();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,6 +83,7 @@ describe('plugin', () => {
     options: {
       defaultRate,
       redisClient,
+      requestAPIKey: (request) => request.auth.credentials.api_key,
       overLimitError: createBoomError('RateLimitExceeded', 429, (rate) => `Rate limit exceeded. Please wait ${rate.window} seconds and try your request again.`)
     }
   }], () => {});
@@ -162,7 +163,7 @@ describe('plugin', () => {
       });
     })
     .then((response) => {
-      expect(response.headers).to.contain.all.keys(['x-rate-limit-reset', 'x-rate-limit-limit', 'x-rate-limit-remaining', 'rate-limit-remaining', 'rate-limit-limit', 'rate-limit-window']);
+      expect(response.headers).to.contain.all.keys(['x-rate-limit-reset', 'x-rate-limit-limit', 'x-rate-limit-remaining']);
       expect(response.statusCode).to.eql(429);
     });
   });
@@ -225,7 +226,7 @@ describe('plugin', () => {
       credentials: { api_key: '123' }
     })
     .then((response) => {
-      expect(response.headers).to.contain.all.keys(['x-rate-limit-reset', 'x-rate-limit-limit', 'x-rate-limit-remaining', 'rate-limit-remaining', 'rate-limit-limit', 'rate-limit-window']);
+      expect(response.headers).to.contain.all.keys(['x-rate-limit-reset', 'x-rate-limit-limit', 'x-rate-limit-remaining']);
     });
   });
 


### PR DESCRIPTION
The `api_key` used in the rate-limiter is now retrieved through a custom getter
