### PR TITLE
feat(rate): abstracted rate to a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ const Hapi = require('hapi');
 
 const server = new Hapi.Server();
 
+const defaultRate = {
+  limit: 10,
+  window: 60
+};
+
 server.register([
   register: require('hapi-rate-limit'),
   options: {
-    defaultRate: {
-      limit: 10,
-      window: 60
-    },
+    defaultRate: (request) => defaultRate,
     redisClient: myThenRedisClient,
     overLimitError: ErrConstructor
   }
@@ -26,6 +28,7 @@ server.register([
 #### Options
 All options `(defaultRate, requestAPIKey, redisClient, overLimitError)` are required for the plugin to work properly.
 ##### `defaultRate`
+Function that accepts a `Request` object and returns:
 ```
 {
   limit: # of max requests allows within window
@@ -46,17 +49,22 @@ If a request count goes over the max limit, this constructor is used to instanti
 Settings for individual routes can be set while registering a route.
 
 #### Custom Rate
-A custom `limit` and `window` can be registered for each route.
+A custom `limit` and `window` can be registered for each route. The `rate` key
+accepts a `Request` object and returns a [rate](#defaultRate).
 
 ```
+const customRate = {
+  limit: 20,
+  window: 30
+};
+
 server.route([{
   method: 'POST',
   path: '/custom_rate_route',
   config: {
     plugins: {
       rateLimit: {
-        limit: 20,
-        window: 30
+        rate: (request) => customRate
       }
     },
     handler: (request, reply) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ exports.register = (server, options, next) => {
       return reply.continue();
     }
 
-    const rate = Object.assign({}, options.defaultRate);
+    let rate = Object.assign({}, options.defaultRate(request));
     const routeSettings = request.route.settings.plugins.rateLimit;
 
     if (routeSettings) {
@@ -17,8 +17,7 @@ exports.register = (server, options, next) => {
         return reply.continue();
       }
 
-      rate.limit = routeSettings.limit;
-      rate.window = routeSettings.window;
+      rate = routeSettings.rate(request);
     }
 
     const key = `hapi-rate-limit:${request.route.method}:${request.route.path}:${options.requestAPIKey(request)}`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,7 +35,9 @@ describe('plugin', () => {
     path: '/short_limit_test',
     config: {
       plugins: {
-        rateLimit: shortLimitRate
+        rateLimit: {
+          rate: () => shortLimitRate
+        }
       },
       handler: (request, reply) => {
         reply({ rate: request.plugins['hapi-rate-limit'].rate });
@@ -47,7 +49,9 @@ describe('plugin', () => {
     path: '/short_window_test',
     config: {
       plugins: {
-        rateLimit: shortWindowRate
+        rateLimit: {
+          rate: () => shortWindowRate
+        }
       },
       handler: (request, reply) => {
         reply({ rate: request.plugins['hapi-rate-limit'].rate });
@@ -81,7 +85,7 @@ describe('plugin', () => {
   server.register([{
     register: require('../lib'),
     options: {
-      defaultRate,
+      defaultRate: () => defaultRate,
       redisClient,
       requestAPIKey: (request) => request.auth.credentials.api_key,
       overLimitError: createBoomError('RateLimitExceeded', 429, (rate) => `Rate limit exceeded. Please wait ${rate.window} seconds and try your request again.`)


### PR DESCRIPTION
### What:

Replaced `defaultRate` and route-custom rates with a function that accepts a `Request` object and returns:

```
{
  limit: # max number of requests within window,
  window: # of seconds before request count resets
}
```

This enables one to return rates on a request-by-request basis (enables custom rates on a more granular basis)
