### PR TITLE
feat(key): generalized account key func

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ server.register([
 ```
 
 #### Options
-All options `(defaultRate, requestAPIKey, redisClient, overLimitError)` are required for the plugin to work properly.
+All options `(defaultRate, rateLimitKey, redisClient, overLimitError)` are required for the plugin to work properly.
 
 Rate-limiting is by default disabled on all routes, unless `enabled=true` in the route plugin [settings](#custom-rate).
 
@@ -41,8 +41,8 @@ Function that accepts a `Request` object and returns:
 
 This is used if there is no `rate` function defined in the route plugin [settings](#custom-rate).
 
-##### `requestAPIKey`
-A function that returns an api_key given a `request` object
+##### `rateLimitKey`
+A function that returns a key for an given request. This can be any differentiating value in each request, such as an API Key, IP Address, etc
 
 ##### `redisClient`
 A `then-redis` client that is already connected

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ exports.register = (server, options, next) => {
 
     const rate = routeSettings.rate ? routeSettings.rate(request) : options.defaultRate(request);
 
-    const key = `hapi-rate-limiter:${request.route.method}:${request.route.path}:${options.requestAPIKey(request)}`;
+    const key = `hapi-rate-limiter:${request.route.method}:${request.route.path}:${options.rateLimitKey(request)}`;
     options.redisClient.multi();
     options.redisClient.set(key, 0, 'EX', rate.window, 'NX'); // if key not found, insert key:0 with window seconds expiry
     options.redisClient.incr(key);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,7 @@ describe('plugin', () => {
       options: {
         defaultRate: () => defaultRate,
         redisClient,
-        requestAPIKey: (request) => request.auth.credentials.api_key,
+        rateLimitKey: (request) => request.auth.credentials.api_key,
         overLimitError: createBoomError('RateLimitExceeded', 429, (rate) => `Rate limit exceeded. Please wait ${rate.window} seconds and try your request again.`)
       }
     }


### PR DESCRIPTION
### What:
- Renamed `requestAPIKey` to `rateLimitKey` to generalize function. Should be a unique identifier that maps to a limited account, not necessarily an API Key. Good catch, @dmlittle 
