### PR TITLE
fix(documentation): update README to latest plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hapi-rate-limit
+# hapi-rate-limiter
 A [Hapi](http://hapijs.com/) plugin that enables rate-limiting for GET, POST, and DELETE requests. This plugin can be configured with custom
 rates on a route-by-route basis.
 
@@ -14,7 +14,7 @@ const defaultRate = {
 };
 
 server.register([
-  register: require('hapi-rate-limit'),
+  register: require('hapi-rate-limiter'),
   options: {
     defaultRate: (request) => defaultRate,
     redisClient: myThenRedisClient,
@@ -74,7 +74,7 @@ server.route([{
       }
     },
     handler: (request, reply) => {
-      reply({ rate: request.plugins['hapi-rate-limit'].rate });
+      reply({ rate: request.plugins['hapi-rate-limiter'].rate });
     }
   }
 }]);
@@ -94,7 +94,7 @@ server.route([{
   path: '/disabled_route',
   config: {
     handler: (request, reply) => {
-      reply({ rate: request.plugins['hapi-rate-limit'].rate });
+      reply({ rate: request.plugins['hapi-rate-limiter'].rate });
     }
   }
 }]);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lob/hapi-rate-limit.git"
+    "url": "https://github.com/lob/hapi-rate-limiter.git"
   },
   "keywords": [
     "hapi"
@@ -21,9 +21,9 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/lob/hapi-rate-limit/issues"
+    "url": "https://github.com/lob/hapi-rate-limiter/issues"
   },
-  "homepage": "https://github.com/lob/hapi-rate-limit",
+  "homepage": "https://github.com/lob/hapi-rate-limiter",
   "dependencies": {},
   "devDependencies": {
     "bluebird": "^3.4.0",


### PR DESCRIPTION
What & why:
- [x] update plugin name in README documentation
- [x] update `homepage` and `bugs` links in package.json

Why: the plugin used to be called `hapi-rate-limit` but the name was already taken by another packaged so we transitioned to `hapi-rate-limiter`.
