### PR TITLE
feat(rateLimitKey): Allows endpoint specification of the rateLimitKey…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,9 @@ exports.register = (server, options, next) => {
     }
 
     const rate = routeSettings.rate ? routeSettings.rate(request) : options.defaultRate(request);
+    const rateLimitKey = routeSettings.rateLimitKey || options.rateLimitKey;
 
-    const key = `hapi-rate-limiter:${request.route.method}:${request.route.path}:${options.rateLimitKey(request)}`;
+    const key = `hapi-rate-limiter:${request.route.method}:${request.route.path}:${rateLimitKey(request)}`;
     options.redisClient.multi();
     options.redisClient.set(key, 0, 'EX', rate.window, 'NX'); // if key not found, insert key:0 with window seconds expiry
     options.redisClient.incr(key);


### PR DESCRIPTION
… function

What: Allow an endpoint's hapi-rate-limiter settings to customize the function used to generate the rate limit key.

Why: Need this functionality for certain endpoints that don't require authentication
- e.g. Instead of using api_key, an endpoint that doesn't require the api_key can use IP address.
