### PR TITLE
chore(redis): remove dependence on then-redis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,12 +18,12 @@ exports.register = (server, options, next) => {
     const rateLimitKey = routeSettings.rateLimitKey || options.rateLimitKey;
 
     const key = `hapi-rate-limiter:${request.route.method}:${request.route.path}:${rateLimitKey(request)}`;
-    options.redisClient.multi();
-    options.redisClient.set(key, 0, 'EX', rate.window, 'NX'); // if key not found, insert key:0 with window seconds expiry
-    options.redisClient.incr(key);
-    options.redisClient.ttl(key);
 
-    return options.redisClient.exec()
+    return options.redisClient.multi()
+    .set(key, 0, 'EX', rate.window, 'NX')
+    .incr(key)
+    .ttl(key)
+    .execAsync()
     .then((results) => {
       const remaining = rate.limit - results[1];
 

--- a/package.json
+++ b/package.json
@@ -37,11 +37,10 @@
     "inject-then": "^2.0.6",
     "istanbul": "^0.4.4",
     "mocha": "^2.5.3",
-    "redis": "^0.12.1",
-    "then-redis": "^1.3.0"
+    "redis": "^2.6.2"
   },
   "peerDependencies": {
     "hapi": ">=11 <14",
-    "then-redis": "^1.3.0"
+    "redis": "^2.6.2"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,9 @@ const expect = require('chai').expect;
 const Bluebird        = require('bluebird');
 const createBoomError = require('create-boom-error');
 const Hapi            = require('hapi');
-const Redis           = require('then-redis');
+const Redis           = require('redis');
+Bluebird.promisifyAll(Redis.RedisClient.prototype);
+Bluebird.promisifyAll(Redis.Multi.prototype);
 
 const redisClient = Redis.createClient({
   port: '6379',


### PR DESCRIPTION
This is an attempt at removing `then-redis` in case it is a source of a bug where we see missing TTLs on rate limit keys. The bug is described more here: https://github.com/antirez/redis/issues/3397
