### PR TITLE
fix(ttl): fixes key expiration race condition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,25 @@
 'use strict';
 
+const SCRIPT = `
+  local current = tonumber(redis.call("incr", KEYS[1]))
+  if current == 1 then
+    redis.call("expire", KEYS[1], ARGV[1])
+  end
+  local ttl = redis.call("ttl", KEYS[1])
+  return {current, ttl}
+`;
+
+let sha;
+
 exports.register = (server, options, next) => {
+
+  server.ext('onPreStart', (extServer, extNext) => {
+    return options.redisClient.scriptAsync('LOAD', SCRIPT)
+    .then((returnSha) => {
+      sha = returnSha;
+      extNext();
+    });
+  });
 
   server.ext('onPostAuth', (request, reply) => {
     request.plugins['hapi-rate-limiter'] = { rate: null };
@@ -19,16 +38,12 @@ exports.register = (server, options, next) => {
 
     const key = `hapi-rate-limiter:${request.route.method}:${request.route.path}:${rateLimitKey(request)}`;
 
-    return options.redisClient.multi()
-    .set(key, 0, 'EX', rate.window, 'NX')
-    .incr(key)
-    .ttl(key)
-    .execAsync()
-    .then((results) => {
-      const remaining = rate.limit - results[1];
+    return options.redisClient.evalshaAsync(sha, 1, key, rate.window)
+    .spread((count, ttl) => {
+      const remaining = rate.limit - count;
 
       rate.remaining = Math.max(remaining, 0);
-      rate.reset = Math.floor(new Date().getTime() / 1000) + results[2];
+      rate.reset = Math.floor(new Date().getTime() / 1000) + ttl;
       request.plugins['hapi-rate-limiter'].rate = rate;
 
       if (remaining < 0) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,6 +126,14 @@ describe('plugin', () => {
     }
   }]);
 
+  before((done) => {
+    server.start(() => done());
+  });
+
+  after((done) => {
+    server.stop(() => done());
+  });
+
   beforeEach(() => {
     return redisClient.flushdb();
   });


### PR DESCRIPTION
🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 🙌  💥  🎉  🎈 

Fixes the race condition that created keys without expirations. This uses a Lua script to create an atomic operation that both increments and conditionally sets and expiration on a key if its value is `1`. I'm using `SCRIPT LOAD` and `EVALSHA` to improve performance. Redis doesn't need to compile the Lua script every time if it is already loaded with `SCRIPT LOAD`.

Some relevant light reading:

* [SCRIPT LOAD](http://redis.io/commands/script-load)
* [EVALSHA](http://redis.io/commands/evalsha)
* [EVAL](http://redis.io/commands/eval)