### PR TITLE
Made overLimitError a function instead of a class for more general usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ exports.register = (server, options, next) => {
       request.plugins['hapi-rate-limiter'].rate = rate;
 
       if (remaining < 0) {
-        return reply(new options.overLimitError(rate));
+        return reply(options.overLimitError(rate));
       }
 
       return reply.continue();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,8 @@ const redisClient = Redis.createClient({
   host: 'localhost'
 });
 
+const RateLimitError = createBoomError('RateLimitExceeded', 429, (rate) => `Rate limit exceeded. Please wait ${rate.window} seconds and try your request again.`);
+
 describe('plugin', () => {
 
   const shortLimitRate = { limit: 1, window: 60 };
@@ -33,7 +35,9 @@ describe('plugin', () => {
         defaultRate: () => defaultRate,
         redisClient,
         rateLimitKey: (request) => request.auth.credentials.api_key,
-        overLimitError: createBoomError('RateLimitExceeded', 429, (rate) => `Rate limit exceeded. Please wait ${rate.window} seconds and try your request again.`)
+        overLimitError: function (rate) {
+          return new RateLimitError(rate);
+        }
       }
     }
   ], () => {});


### PR DESCRIPTION
The package expects overLimitError to be a class, and although it makes sense to use a class in some cases, it does not always apply, so I'm introducing this change and in test/index.test.js there's an example usage of errors that are still classes, and how they would still work.