### PR TITLE
fix(redis): handle redis error and continue the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ server.register({
     defaultRate: (request) => defaultRate,
     rateLimitKey: (request) => request.auth.credentials.apiKey,
     redisClient: RedisClient,
-    overLimitError: (rate) => new Error(`Rate Limit Exceeded - try again in ${rate.window} seconds`)
+    overLimitError: (rate) => new Error(`Rate Limit Exceeded - try again in ${rate.window} seconds`),
+    onRedisError: (err) => console.log(err)
   }
 }, (err) => {
 
@@ -65,6 +66,9 @@ A promisified redis client
 
 ##### `overLimitError`
 A function that is called when the rate limit is exceeded. It must return an error. It is called with an object `rate` that contains information about the current state of the request rate.
+
+##### `onRedisError`
+An optional function that is called when the call to the Redis client errors. It is called with the `err` from the Redis client.
 
 ## Managing Routes
 Settings for individual routes can be set while registering a route.

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,8 +57,16 @@ exports.register = (server, options, next) => {
       }
 
       return reply.continue();
-    });
+    })
+    .catch((err) => {
+      // If the Redis call failed, call the onRedisError function,
+      // then continue with the request.
+      if (options.onRedisError) {
+        options.onRedisError(err);
+      }
 
+      return reply.continue();
+    });
   });
 
   server.ext('onPreResponse', (request, reply) => {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "inject-then": "^2.0.6",
     "istanbul": "^0.4.4",
     "mocha": "^2.5.3",
-    "redis": "^2.6.2"
+    "redis": "^2.6.2",
+    "sinon": "^7.2.0"
   },
   "peerDependencies": {
     "hapi": ">=11 <17",


### PR DESCRIPTION
## What

* If the Redis client call to `evalshaAsync` returns a rejected promise, call `onRedisError` if set, and continue the request lifecyle

## Why

* With the current logic, an error in the Redis call leads to a request that hangs forever because `reply.continue()` is never called.