### PR TITLE
feat(timer): adds timer option and simplifies key option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ server.register({
   register: require('hapi-rate-limiter'),
   options: {
     defaultRate: (request) => defaultRate,
-    rateLimitKey: (request) => request.auth.credentials.apiKey,
+    key: (request) => request.auth.credentials.apiKey,
     redisClient: RedisClient,
     overLimitError: (rate) => new Error(`Rate Limit Exceeded - try again in ${rate.window} seconds`),
-    onRedisError: (err) => console.log(err)
+    onRedisError: (err) => console.log(err),
+    timer: (ms) => console.log(`Rate Limit Latency - ${ms} milliseconds`)
   }
 }, (err) => {
 
@@ -38,9 +39,9 @@ server.register({
 ```
 
 #### Options
-The following options are required for the plugin to work properly: `(defaultRate, rateLimitKey, redisClient, overLimitError)`.
+The following options are required for the plugin to work properly: `(defaultRate, key, redisClient, overLimitError)`.
 
-The `rateLimitKeyPrefix` option is optional and defaults to: `(request) => request.route.method + ':' + request.route.path;`.
+The `keyPrefix` option is optional and defaults to: `(request) => request.route.method + ':' + request.route.path;`.
 
 Rate-limiting is by default disabled on all routes, unless `enabled=true` in the route plugin [settings](#custom-rate).
 
@@ -55,11 +56,11 @@ Function that accepts a `Request` object and returns:
 
 This is used if there is no `rate` function defined in the route plugin [settings](#custom-rate).
 
-##### `rateLimitKey`
+##### `key`
 A function that returns a key for a given request. This can be any differentiating value in each request, such as an API Key, IP Address, etc
 
-##### `rateLimitKeyPrefix`
-A function that returns a prefix (string) for a given request. The `rateLimitKeyPrefix` is combined with the `rateLimitKey` to look up the rate-limiting information for a given request. By default, the rate limits are enforced on a per route basis. If you want the rate limit to apply to all routes, then return a constant value from this function.
+##### `keyPrefix`
+A function that returns a prefix (string) for a given request. The `keyPrefix` is combined with the `key` to look up the rate-limiting information for a given request. By default, the rate limits are enforced on a per route basis. If you want the rate limit to apply to all routes, then return a constant value from this function.
 
 ##### `redisClient`
 A promisified redis client
@@ -69,6 +70,9 @@ A function that is called when the rate limit is exceeded. It must return an err
 
 ##### `onRedisError`
 An optional function that is called when the call to the Redis client errors. It is called with the `err` from the Redis client.
+
+##### `timer`
+An optional function that will be called upon every rate limit request. The argument will be the time in milliseconds to perform the rate limit process.
 
 ## Managing Routes
 Settings for individual routes can be set while registering a route.
@@ -104,7 +108,7 @@ To enable rate-limiting for a route, `enabled` must be `true` in the route plugi
 
 `rate` can also be defined in these settings to set a custom rate. If this is not defined, `defaultRate` will be used.
 
-`rateLimitKey` and `rateLimitKeyPrefix` can also be defined in these settings to override the values set in the plugin options.
+`key` and `keyPrefix` can also be defined in these settings to override the values set in the plugin options.
 
 #### Disable Rate-Limiting for route
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const MS_PER_SECOND = 1e3;
+const NS_PER_MS     = 1e6;
+
 const SCRIPT = `
   local current = tonumber(redis.call("incr", KEYS[1]))
   if current == 1 then
@@ -10,6 +13,33 @@ const SCRIPT = `
 `;
 
 let sha;
+
+function isEnabled (routeSettings, request) {
+  const method = request.route.method;
+  const validMethod = method === 'get' || method === 'post' || method === 'delete';
+  const enabled = routeSettings && routeSettings.enabled;
+
+  return validMethod && enabled;
+}
+
+function defaultKeyPrefix (request) {
+  return `${request.route.method}:${request.route.path}`;
+}
+
+function getKey (options, routeSettings, request) {
+  const prefixFn = routeSettings.keyPrefix || options.keyPrefix || defaultKeyPrefix;
+  const prefix = prefixFn(request);
+
+  const keyFn = routeSettings.key || options.key;
+  const key = keyFn(request);
+
+  return `hapi-rate-limiter:${prefix}:${key}`;
+}
+
+function getRate (options, routeSettings, request) {
+  const rateFn = routeSettings.rate || options.defaultRate;
+  return rateFn(request);
+}
 
 exports.register = (server, options, next) => {
 
@@ -22,27 +52,21 @@ exports.register = (server, options, next) => {
   });
 
   server.ext('onPostAuth', (request, reply) => {
+    let startTime;
+    const routeSettings = request.route.settings.plugins.rateLimit;
+
     request.plugins['hapi-rate-limiter'] = { rate: null };
 
-    if (!(request.route.method === 'get' || request.route.method === 'post' || request.route.method === 'delete')) {
+    if (!isEnabled(routeSettings, request)) {
       return reply.continue();
     }
 
-    const routeSettings = request.route.settings.plugins.rateLimit;
-    if (!routeSettings || !routeSettings.enabled) {
-      return reply.continue();
+    if (options.timer) {
+      startTime = process.hrtime();
     }
 
-    const rate = routeSettings.rate ? routeSettings.rate(request) : options.defaultRate(request);
-
-    const defaultRateLimitPrefix = (req) => `${req.route.method}:${req.route.path}`;
-
-    const rateLimitKeyPrefix = routeSettings.rateLimitKeyPrefix || options.rateLimitKeyPrefix ||
-        defaultRateLimitPrefix;
-
-    const rateLimitKey = routeSettings.rateLimitKey || options.rateLimitKey;
-
-    const key = `hapi-rate-limiter:${rateLimitKeyPrefix(request)}:${rateLimitKey(request)}`;
+    const rate = getRate(options, routeSettings, request);
+    const key = getKey(options, routeSettings, request);
 
     return options.redisClient.evalshaAsync(sha, 1, key, rate.window)
     .spread((count, ttl) => {
@@ -66,6 +90,14 @@ exports.register = (server, options, next) => {
       }
 
       return reply.continue();
+    })
+    .finally(() => {
+      if (options.timer) {
+        const diff = process.hrtime(startTime);
+        const milliseconds = diff[0] * MS_PER_SECOND + diff[1] / NS_PER_MS;
+
+        options.timer(milliseconds);
+      }
     });
   });
 
@@ -74,7 +106,7 @@ exports.register = (server, options, next) => {
     const rate = request.plugins['hapi-rate-limiter'] ? request.plugins['hapi-rate-limiter'].rate : null;
 
     if (rate) {
-      // if an error was thrown, set headers on error-response instead
+      // If an error was thrown, set headers on the error-response.
       const headers = request.response.output ? request.response.output.headers : request.response.headers;
 
       headers['X-Rate-Limit-Remaining'] = rate.remaining;


### PR DESCRIPTION
## What

* Adds a `timer` callback which is called with the number of milliseconds it took to perform rate limiting.
* Cleans up code with helper functions.
* Renames `rateLimitKey` and `rateLimitKeyPrefix` to `key` and `keyPrefix`, respectively.

## Why

The `timer` callback will allow us to track metrics to see how much overhead rate-limiting is incurring, and if it may be a bottleneck.

The rest of the changes are for user and developer friendliness.