### PR TITLE
fix(timer): measures time taken more accurately

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,8 @@ exports.register = (server, options, next) => {
 
   server.ext('onPostAuth', (request, reply) => {
     let startTime;
+    let timeDiff;
+
     const routeSettings = request.route.settings.plugins.rateLimit;
 
     request.plugins['hapi-rate-limiter'] = { rate: null };
@@ -76,6 +78,10 @@ exports.register = (server, options, next) => {
       rate.reset = Math.floor(new Date().getTime() / 1000) + ttl;
       request.plugins['hapi-rate-limiter'].rate = rate;
 
+      if (options.timer) {
+        timeDiff = process.hrtime(startTime);
+      }
+
       if (remaining < 0) {
         return reply(options.overLimitError(rate));
       }
@@ -83,6 +89,11 @@ exports.register = (server, options, next) => {
       return reply.continue();
     })
     .catch((err) => {
+
+      if (options.timer) {
+        timeDiff = process.hrtime(startTime);
+      }
+
       // If the Redis call failed, call the onRedisError function,
       // then continue with the request.
       if (options.onRedisError) {
@@ -93,8 +104,7 @@ exports.register = (server, options, next) => {
     })
     .finally(() => {
       if (options.timer) {
-        const diff = process.hrtime(startTime);
-        const milliseconds = diff[0] * MS_PER_SECOND + diff[1] / NS_PER_MS;
+        const milliseconds = timeDiff[0] * MS_PER_SECOND + timeDiff[1] / NS_PER_MS;
 
         options.timer(milliseconds);
       }


### PR DESCRIPTION
## What

* Calculates the time taken before calling `reply()` or `reply.continue()`
* I may be wrong, but I think by calling those functions first (which are promises), the time taken includes the time for those promises to resolve.
* I'm not sure exactly how or when they resolve, but they could potentially not resolve until other plugins or the handler is invoked, or finishes invoking.
* Therefore, I think this is a more accuratey measuring of time for this rate limit plugin.