### PR TITLE
removing requirement that Redis be promisified via Bluebird

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ const Bluebird = require('bluebird');
 const Hapi     = require('hapi');
 const Redis    = require('redis');
 
+// Note: Sadly, this package currently requires a promisified Redis client
+// Luckily, any package appending *Async methods should work, not just Bluebird
 Bluebird.promisifyAll(Redis.RedisClient.prototype);
 Bluebird.promisifyAll(Redis.Multi.prototype);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ exports.register = (server, options, next) => {
     const key = getKey(options, routeSettings, request);
 
     return options.redisClient.evalshaAsync(sha, 1, key, rate.window)
-    .spread((count, ttl) => {
+    .then(([count, ttl]) => {
       const remaining = rate.limit - count;
 
       rate.remaining = Math.max(remaining, 0);


### PR DESCRIPTION
- will now support Redis clients promisified by `util-promisify`, `pifall`, etc
- still compatible with Bluebird
- ergo consider this a PATCH release