### PR TITLE
Add request and response toolkit to the overLimitError

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ await server.register({
     defaultRate: (request) => defaultRate,
     key: (request) => request.auth.credentials.apiKey,
     redisClient: RedisClient,
-    overLimitError: (rate) => new Error(`Rate Limit Exceeded - try again in ${rate.window} seconds`),
+    overLimitError: (rate, request, h) => new Error(`Rate Limit Exceeded - try again in ${rate.window} seconds`),
     onRedisError: (err) => console.log(err),
     timer: (ms) => console.log(`Rate Limit Latency - ${ms} milliseconds`)
   }
@@ -67,7 +67,7 @@ A function that returns a prefix (string) for a given request. The `keyPrefix` i
 A promisified redis client
 
 ##### `overLimitError`
-A function that is called when the rate limit is exceeded. It must return an error. It is called with an object `rate` that contains information about the current state of the request rate.
+A function that is called when the rate limit is exceeded. It must return an error. It is called with an object `rate` that contains information about the current state of the request rate, the `request` and `h` the response toolkit.
 
 ##### `onRedisError`
 An optional function that is called when the call to the Redis client errors. It is called with the `err` from the Redis client.

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ exports.register = (server, options) => {
       }
 
       if (remaining < 0) {
-        return options.overLimitError(rate);
+        return options.overLimitError(rate, request, h);
       }
 
       return h.continue;


### PR DESCRIPTION
It is useful to have more context on the `overLimitError` mainly for logging purposes. That is why I propose to add the `request` argument. 
Also, I want to implement a "passive mode", with the rate limit enabled but only for logging purposes, with no blocking. That's why the `h` param is useful to be able to return `h.continue`.