### PR TITLE
Allow to disable rate limit headers by setting noHeaders globally or per route

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ An optional function that is called when the call to the Redis client errors. It
 ##### `timer`
 An optional function that will be called upon every rate limit request. The argument will be the time in milliseconds to perform the rate limit process.
 
+##### `noHeaders`
+An optional boolean to no set rate limit headers on the response.
+
 ## Managing Routes
 Settings for individual routes can be set while registering a route.
 
@@ -135,3 +138,5 @@ Rate-limiting information for each request is attached to the response header wi
 `x-rate-limit-remaining:` remaining number of requests allows within current window
 
 `x-rate-limit-reset:` time when rate-limiter will reset (UTC seconds-since-epoch)
+
+You can disable those by settings `noHeaders: true` on the plugin options or on per-route basis.

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,9 +104,10 @@ exports.register = (server, options) => {
   });
 
   server.ext('onPreResponse', async (request, h) => {
+    const routeSettings = request.route.settings.plugins.rateLimit;
     const rate = request.plugins['hapi-rate-limiter'] ? request.plugins['hapi-rate-limiter'].rate : null;
 
-    if (rate) {
+    if (rate && !(routeSettings.noHeaders || options.noHeaders)) {
       // If an error was thrown, set headers on the error-response.
       const headers = request.response.output ? request.response.output.headers : request.response.headers;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,6 +73,21 @@ describe('plugin', async () => {
   },
   {
     method: 'POST',
+    path: '/default_no_headers',
+    config: {
+      plugins: {
+        rateLimit: {
+          enabled: true,
+          noHeaders: true
+        }
+      },
+      handler: (request) => {
+        return { rate: request.plugins['hapi-rate-limiter'].rate };
+      }
+    }
+  },
+  {
+    method: 'POST',
     path: '/short_limit_test',
     config: {
       plugins: {
@@ -430,6 +445,20 @@ describe('plugin', async () => {
     })
       .then((response) => {
         expect(response.headers).to.contain.all.keys(['x-rate-limit-reset', 'x-rate-limit-limit', 'x-rate-limit-remaining']);
+      });
+  });
+
+  it('allows to not returns the headers', () => {
+    return server.inject({
+      method: 'POST',
+      url: '/default_no_headers',
+      auth: {
+        credentials: { api_key: '123' },
+        strategy: 'basic'
+      }
+    })
+      .then((response) => {
+        expect(response.headers).to.not.contain.all.keys(['x-rate-limit-reset', 'x-rate-limit-limit', 'x-rate-limit-remaining']);
       });
   });
 


### PR DESCRIPTION
Sometimes you do not want to returns the rate limit headers for "security" reasons. I added an option `noHeaders` to disable those.